### PR TITLE
warn clients not to double render CID referenced parts

### DIFF
--- a/draft-ietf-mimi-content.md
+++ b/draft-ietf-mimi-content.md
@@ -462,10 +462,7 @@ Using
 When processing a MultiPart nested structure, the client can start from the
 `body` in the MIMI content (the "top-level" or "root") and evaluate any
 `chooseOne` semantics MultiPart elements, effectively discarding non-chosen
-Parts. To prevent rendering a Part referenced in a content ID URI more that
-once, the client can walk through the remaining parts in order, rendering any
-parts with the `render` or `inline` dispositions that were not already
-previously rendered based on their content ID reference.
+Parts. The remaining Parts might still reference each other in content ID URI. To prevent rendering a Part more than once, the client can handle the remaining Parts in order, skipping a Part if it was already referred to by a previously handled Part. If a MultiPart is skipped, all inner Parts are skipped too. All dispositions are handled the same: If a Part of disposition "reaction" is skipped, the reaction will not be counted. If a Part of disposition "attachment" is skipped, it will not be be visible in the attachment list.
 
 
 ## External content {#external}

--- a/draft-ietf-mimi-content.md
+++ b/draft-ietf-mimi-content.md
@@ -457,6 +457,15 @@ The partIndex can be used inside a content ID URI [@!RFC2392] in a "container"
 part (for example HTML, Markdown, vCard [@?RFC6350], or iCal [@?RFC5545]) to
 reference another part inside the same MIMI message. In a MIMI message it has
 the form `cid:`*partIndex*`@local.invalid`.
+Using 
+
+When processing a MultiPart nested structure, the client can start from the
+`body` in the MIMI content (the "top-level" or "root") and evaluate any
+`chooseOne` semantics MultiPart elements, effectively discarding non-chosen
+Parts. To prevent rendering a Part referenced in a content ID URI more that
+once, the client can walk through the remaining parts in order, rendering any
+parts with the `render` or `inline` dispositions that were not already
+previously rendered based on their content ID reference.
 
 
 ## External content {#external}

--- a/draft-ietf-mimi-content.md
+++ b/draft-ietf-mimi-content.md
@@ -462,7 +462,11 @@ This format of the content ID URI in MIMI MUST only reference the `partIndex` of
 When processing a MultiPart nested structure, the client can start from the
 `body` in the MIMI content (the "top-level" or "root") and evaluate any
 `chooseOne` semantics MultiPart elements, effectively discarding non-chosen
-Parts. The remaining Parts might still reference each other in content ID URI. To prevent rendering a Part more than once, the client can handle the remaining Parts in order, skipping a Part if it was already referred to by a previously handled Part. If a MultiPart is skipped, all inner Parts are skipped too. All dispositions are handled the same: If a Part of disposition "reaction" is skipped, the reaction will not be counted. If a Part of disposition "attachment" is skipped, it will not be be visible in the attachment list.
+Parts. The remaining Parts might still reference each other in content ID URI.
+To prevent processing a Part more than once, the client can handle the remaining
+Parts in order, skipping any Parts already referenced by a previously handled
+Part. This process of skipping already processed Parts is respected regardless
+of the disposition of the Part.
 
 
 ## External content {#external}

--- a/draft-ietf-mimi-content.md
+++ b/draft-ietf-mimi-content.md
@@ -457,7 +457,7 @@ The partIndex can be used inside a content ID URI [@!RFC2392] in a "container"
 part (for example HTML, Markdown, vCard [@?RFC6350], or iCal [@?RFC5545]) to
 reference another part inside the same MIMI message. In a MIMI message it has
 the form `cid:`*partIndex*`@local.invalid`.
-Using 
+This format of the content ID URI in MIMI MUST only reference the `partIndex` of a SinglePart or ExternalPart.
 
 When processing a MultiPart nested structure, the client can start from the
 `body` in the MIMI content (the "top-level" or "root") and evaluate any


### PR DESCRIPTION
Give guidance to clients about processing MultiPart (including nested MultiPart) content.
- ignore the parts that are not chosen from chooseOne
- make sure that parts referenced by content ID (CID) URIs aren't rendered twice.

addresses #30 

@timokoesters 